### PR TITLE
Politica de privacidade

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,6 +1,0 @@
-DB_HOST='localhost'
-DB_USER='usuario_exemplo'
-DB_PASSWORD='senha_exemplo'
-DB_DATABASE='banco_exemplo'
-DOCKERFILE=Dockerfile
-# DOCKERFILE=Dockerfile.prod

--- a/backend/app.js
+++ b/backend/app.js
@@ -481,7 +481,7 @@ app.post('/alterar-senha', async (req, res) => {
   }
 });
 
-// Endpoint para registrar aceite do termo de uso
+// Endpoint para registrar aceite da Política de Privacidade
 app.post('/aceitar-termo', async (req, res) => {
   const { id_cliente } = req.body;
 
@@ -493,10 +493,10 @@ app.post('/aceitar-termo', async (req, res) => {
     const query = 'UPDATE clientes SET termo_aceito = TRUE WHERE id_cliente = $1';
     await pool.query(query, [id_cliente]);
 
-    res.json({ success: true, message: 'Termo aceito com sucesso!' });
+    res.json({ success: true, message: 'Política de Privacidade aceita com sucesso!' });
   } catch (error) {
-    console.error('Erro ao registrar aceite do termo:', error);
-    res.status(500).json({ success: false, message: 'Erro ao registrar aceite do termo' });
+    console.error('Erro ao registrar aceite da Política de Privacidade:', error);
+    res.status(500).json({ success: false, message: 'Erro ao registrar aceite da Política de Privacidade' });
   }
 });
 

--- a/frontend/public/termos-de-uso.html
+++ b/frontend/public/termos-de-uso.html
@@ -1,0 +1,132 @@
+<!DOCTYPE html>
+<html lang="pt-BR">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Política de Privacidade - DogVideo</title>
+  <style>
+    body {
+      font-family: 'Glacial Indifference', sans-serif;
+      background-color: #000;
+      color: #fff;
+      margin: 0;
+      padding: 40px;
+      line-height: 1.6;
+    }
+
+    h1, h2, a {
+      color: #fff;
+    }
+
+    a {
+      color: #87cefa;
+      text-decoration: underline;
+    }
+
+    p, li {
+      margin-bottom: 12px;
+      font-size: 18px;
+    }
+
+    ul {
+      list-style-type: disc;
+      margin-left: 40px;
+    }
+
+    footer {
+      margin-top: 40px;
+      font-size: 16px;
+      color: #aaa;
+      text-align: center;
+    }
+
+    @media (max-width: 768px) {
+      body {
+        padding: 20px;
+        font-size: 16px;
+      }
+    }
+  </style>
+</head>
+<body>
+  <h1>Política de Privacidade — DogVideo</h1>
+  <p><strong>Última atualização:</strong> 17 de outubro de 2025</p>
+  <p><strong>Site:</strong> <a href="https://dogvideo.com.br" target="_blank">dogvideo.com.br</a></p>
+
+  <h2>1. Dados coletados</h2>
+  <p>Ao se cadastrar e contratar uma assinatura, a DogVideo poderá coletar as seguintes informações pessoais fornecidas pelo próprio usuário:</p>
+  <ul>
+    <li>Nome completo;</li>
+    <li>CPF;</li>
+    <li>Telefone;</li>
+    <li>E-mail;</li>
+    <li>Endereço (residencial ou de cobrança);</li>
+    <li>Tipo de assinatura (plano contratado e status da assinatura).</li>
+  </ul>
+  <p><strong>Importante:</strong> A DogVideo não coleta nem armazena dados bancários ou informações de cartão de crédito. Os pagamentos são realizados fora da plataforma, por meios externos escolhidos pelo usuário, e não ficam sob controle ou armazenamento da DogVideo.</p>
+
+  <h2>2. Finalidades do tratamento de dados</h2>
+  <p>Os dados pessoais coletados são utilizados exclusivamente para as seguintes finalidades legítimas e específicas:</p>
+  <ul>
+    <li>Gerenciar e controlar assinaturas e planos;</li>
+    <li>Monitorar o status de pagamentos quando vinculados à prestação do serviço;</li>
+    <li>Cumprir obrigações legais e administrativas.</li>
+  </ul>
+  <p>A DogVideo não utiliza os dados para fins de marketing, não compartilha com terceiros para fins comerciais e não realiza qualquer processamento adicional sem base legal ou consentimento do titular.</p>
+
+  <h2>3. Bases legais para o tratamento</h2>
+  <p>O tratamento de dados pessoais é realizado com base nas seguintes hipóteses previstas na LGPD:</p>
+  <ul>
+    <li>Execução de contrato ou procedimentos preliminares relacionados à assinatura;</li>
+    <li>Cumprimento de obrigação legal ou regulatória;</li>
+    <li>Legítimo interesse, para fins administrativos e de controle interno;</li>
+    <li>Consentimento, quando aplicável a finalidades específicas adicionais.</li>
+  </ul>
+  <p>O usuário poderá revogar o consentimento a qualquer momento, sem prejuízo das operações realizadas anteriormente.</p>
+
+  <h2>4. Compartilhamento de dados</h2>
+  <p>A DogVideo não compartilha dados pessoais com terceiros, salvo nas seguintes situações:</p>
+  <ul>
+    <li>Para cumprimento de obrigação legal, regulatória ou ordem judicial;</li>
+    <li>Para defesa de direitos da DogVideo em processos administrativos ou judiciais;</li>
+    <li>Em operações estritamente necessárias para a prestação do serviço, assegurando que eventuais parceiros atuem conforme esta política e as normas da LGPD.</li>
+  </ul>
+  <p>Como os pagamentos são realizados fora da plataforma, não há transferência de dados bancários pela DogVideo.</p>
+
+  <h2>5. Retenção e eliminação dos dados</h2>
+  <p>Os dados pessoais serão armazenados de forma segura durante o uso dos serviços e por até 6 (seis) meses após o cancelamento da assinatura, para fins administrativos e cumprimento de obrigações legais.</p>
+  <p>Após esse prazo, os dados serão excluídos de forma definitiva e segura, salvo se houver obrigação legal de retenção por período superior, hipótese em que o usuário será informado.</p>
+
+  <h2>6. Segurança da informação</h2>
+  <p>A DogVideo adota medidas técnicas e organizacionais adequadas para proteger os dados pessoais contra acessos não autorizados, perda, alteração ou uso indevido.</p>
+  <p>Embora empregue práticas de segurança alinhadas às boas práticas de mercado, nenhum sistema é totalmente imune a riscos. Caso ocorra um incidente de segurança envolvendo dados pessoais, a DogVideo tomará medidas imediatas para mitigação e comunicará as autoridades competentes e os titulares, conforme exigido pela legislação.</p>
+
+  <h2>7. Direitos dos titulares dos dados</h2>
+  <p>Nos termos da LGPD, o titular dos dados tem direito a:</p>
+  <ul>
+    <li>Confirmar a existência de tratamento;</li>
+    <li>Acessar seus dados pessoais;</li>
+    <li>Corrigir dados incompletos, inexatos ou desatualizados;</li>
+    <li>Solicitar a eliminação de dados desnecessários ou excessivos;</li>
+    <li>Solicitar a portabilidade dos dados, quando aplicável;</li>
+    <li>Revogar o consentimento a qualquer momento;</li>
+    <li>Obter informações sobre eventual compartilhamento de dados.</li>
+  </ul>
+  <p>Para exercer qualquer um desses direitos, o usuário pode entrar em contato através do e-mail: <a href="mailto:comercial@dogvideo.com.br">comercial@dogvideo.com.br</a>.</p>
+
+  <h2>8. Tratamento de dados de crianças e adolescentes</h2>
+  <p>Os serviços da DogVideo não são destinados a menores de 18 anos. Caso seja identificado o fornecimento de dados por menores sem autorização dos responsáveis legais, esses dados serão imediatamente excluídos.</p>
+
+  <h2>9. Alterações desta Política</h2>
+  <p>A DogVideo poderá alterar esta Política de Privacidade a qualquer momento. A versão mais atual estará sempre disponível em: <a href="https://dogvideo.com.br/politica-de-privacidade" target="_blank">dogvideo.com.br/politica-de-privacidade</a>.</p>
+  <p>Recomenda-se que o usuário revise periodicamente esta política para se manter informado sobre as práticas adotadas.</p>
+
+  <h2>10. Contato</h2>
+  <p>Em caso de dúvidas, solicitações ou reclamações relacionadas à privacidade e ao tratamento de dados pessoais, entre em contato com o responsavel pelo e-mail: <a href="mailto:comercial@dogvideo.com.br">comercial@dogvideo.com.br</a>.</p>
+
+  <footer>
+    <p>DogVideo — Todos os direitos reservados.<br>
+    <a href="https://dogvideo.com.br" target="_blank">dogvideo.com.br</a></p>
+  </footer>
+</body>
+</html>

--- a/frontend/public/termos-de-uso.html
+++ b/frontend/public/termos-de-uso.html
@@ -14,6 +14,20 @@
       line-height: 1.6;
     }
 
+    .Web-header-inicial {
+      background-color: black;
+      height: 90px;
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      position: relative;
+    }
+
+    .Web-logotipo {
+      height: 160px;
+      margin: 0;
+    }
+
     h1, h2, a {
       color: #fff;
     }
@@ -45,10 +59,22 @@
         padding: 20px;
         font-size: 16px;
       }
+
+      .Web-logotipo {
+        height: 100px;
+      }
+
+      .Web-header-inicial {
+        height: 70px;
+      }
     }
   </style>
 </head>
 <body>
+  <header class="Web-header-inicial">
+    <img src="logotipo.svg" alt="DogVideo Logotipo" class="Web-logotipo" />
+  </header>
+
   <h1>Política de Privacidade — DogVideo</h1>
   <p><strong>Última atualização:</strong> 17 de outubro de 2025</p>
   <p><strong>Site:</strong> <a href="https://dogvideo.com.br" target="_blank">dogvideo.com.br</a></p>
@@ -122,7 +148,7 @@
   <p>Recomenda-se que o usuário revise periodicamente esta política para se manter informado sobre as práticas adotadas.</p>
 
   <h2>10. Contato</h2>
-  <p>Em caso de dúvidas, solicitações ou reclamações relacionadas à privacidade e ao tratamento de dados pessoais, entre em contato com o responsavel pelo e-mail: <a href="mailto:comercial@dogvideo.com.br">comercial@dogvideo.com.br</a>.</p>
+  <p>Em caso de dúvidas, solicitações ou reclamações relacionadas à privacidade e ao tratamento de dados pessoais, entre em contato com o responsável pelo e-mail: <a href="mailto:comercial@dogvideo.com.br">comercial@dogvideo.com.br</a>.</p>
 
   <footer>
     <p>DogVideo — Todos os direitos reservados.<br>

--- a/frontend/src/DadosCliente/dados.css
+++ b/frontend/src/DadosCliente/dados.css
@@ -173,7 +173,7 @@ li {
   background-color: #747070;
 }
 
-/* Link fixo para Termos de Uso */
+/* Link fixo para Política de Privacidade */
 .link-termos {
   position: fixed;
   bottom: 10px;

--- a/frontend/src/DadosCliente/dados.css
+++ b/frontend/src/DadosCliente/dados.css
@@ -48,7 +48,6 @@ body {
   margin-top: 40px;
 }
 
-
 .Dados-grid {
   display: flex;
   justify-content: space-evenly;
@@ -174,6 +173,24 @@ li {
   background-color: #747070;
 }
 
+/* Link fixo para Termos de Uso */
+.link-termos {
+  position: fixed;
+  bottom: 10px;
+  right: 15px;
+  font-family: 'Glacial Indifference', sans-serif;
+  font-size: 16px;
+  color: #87cefa;
+  text-decoration: underline;
+  cursor: pointer;
+  z-index: 1000;
+  transition: color 0.3s ease;
+}
+
+.link-termos:hover {
+  color: #ffffff;
+}
+
 /* Responsividade para telas menores */
 @media (max-width: 768px) {
   .Web-header {
@@ -222,6 +239,13 @@ li {
 
   .modal-title {
     font-size: 16px;
+  }
+
+  /* 🔹 Ajuste do link em telas menores */
+  .link-termos {
+    font-size: 14px;
+    bottom: 8px;
+    right: 10px;
   }
 }
 
@@ -283,5 +307,12 @@ li {
   .reset-password-button {
     font-size: 14px;
     padding: 8px 16px;
+  }
+
+  /* 🔹 Ajuste do link em smartphones */
+  .link-termos {
+    font-size: 13px;
+    bottom: 6px;
+    right: 8px;
   }
 }

--- a/frontend/src/DadosCliente/dados.js
+++ b/frontend/src/DadosCliente/dados.js
@@ -163,15 +163,15 @@ function Dados({ onLogout }) {
         </div>
       </main>
 
-      {/* Link fixo para Termos de Uso */}
-        <a
-          href={`${process.env.PUBLIC_URL}/termos-de-uso.html`}
-          target="_blank"
-          rel="noopener noreferrer"
-          className="link-termos"
-        >
-          Política de Privacidade
-        </a>
+      {/* Link fixo para Política de Privacidade */}
+      <a
+        href={`${process.env.PUBLIC_URL}/termos-de-uso.html`}
+        target="_blank"
+        rel="noopener noreferrer"
+        className="link-termos"
+      >
+        Política de Privacidade
+      </a>
     </div>
   );
 }

--- a/frontend/src/DadosCliente/dados.js
+++ b/frontend/src/DadosCliente/dados.js
@@ -91,7 +91,7 @@ function Dados({ onLogout }) {
           className="Web-logotipo"
           alt="Dogvideo Logotipo"
         />
-               
+
         <button className="reset-password-button" onClick={handleResetPassword}>
           Redefinir Senha
         </button>
@@ -162,6 +162,16 @@ function Dados({ onLogout }) {
           </div>
         </div>
       </main>
+
+      {/* Link fixo para Termos de Uso */}
+        <a
+          href={`${process.env.PUBLIC_URL}/termos-de-uso.html`}
+          target="_blank"
+          rel="noopener noreferrer"
+          className="link-termos"
+        >
+          Política de Privacidade
+        </a>
     </div>
   );
 }

--- a/frontend/src/RedefinirSenha/redefinir.css
+++ b/frontend/src/RedefinirSenha/redefinir.css
@@ -163,3 +163,29 @@
     }
   }
   
+  .checkbox-termos {
+  margin-top: 25px;
+  font-family: 'Glacial Indifference', sans-serif;
+  font-size: 18px;
+  color: #fff;
+  text-align: left;
+  width: 450px;
+  display: flex;
+  align-items: center;
+  gap: 10px;
+}
+
+.checkbox-termos a {
+  color: #87cefa;
+  text-decoration: underline;
+}
+
+.checkbox-termos input {
+  width: 20px;
+  height: 20px;
+  cursor: pointer;
+}
+
+
+
+  

--- a/frontend/src/RedefinirSenha/redefinir.js
+++ b/frontend/src/RedefinirSenha/redefinir.js
@@ -62,7 +62,7 @@ function Redefinir() {
       return;
     }
 
-    if (!termoAceito) {
+    if (alterarSenha === 1 && !termoAceito) {
       setError('Você precisa aceitar a Política de Privacidade antes de redefinir a senha.');
       return;
     }
@@ -71,7 +71,7 @@ function Redefinir() {
       
 
       // Envia a nova senha e o aceite dos termos
-      const id_cliente = localStorage.getItem('id_cliente'); // ✅ pega o id real salvo no login
+      const id_cliente = localStorage.getItem('id_cliente');
 
       const response = await fetch('http://localhost:3001/alterar-senha', {
         method: 'POST',
@@ -171,24 +171,26 @@ function Redefinir() {
       </div>
 
       {/* Checkbox dos Termos de Uso */}
-      <div className="checkbox-termos">
-        <input
-          type="checkbox"
-          id="termoUso"
-          checked={termoAceito}
-          onChange={(e) => setTermoAceito(e.target.checked)}
-        />
-        <label htmlFor="termoUso">
-          Eu li e aceito a{" "}
-          <a
-            href={`${process.env.PUBLIC_URL}/termos-de-uso.html`}
-            target="_blank"
-            rel="noopener noreferrer"
-          >
-            Política de Privacidade
-          </a>
-        </label>
-      </div>
+      {alterarSenha === 1 && (
+        <div className="checkbox-termos">
+          <input
+            type="checkbox"
+            id="termoUso"
+            checked={termoAceito}
+            onChange={(e) => setTermoAceito(e.target.checked)}
+          />
+          <label htmlFor="termoUso">
+            Eu li e aceito os{" "}
+            <a
+              href={`${process.env.PUBLIC_URL}/termos-de-uso.html`}
+              target="_blank"
+              rel="noopener noreferrer"
+            >
+              Termos de Uso
+            </a>
+          </label>
+        </div>
+      )}
 
       {error && <p className="error">{error}</p>}
       <button onClick={handlePasswordChange}>Redefinir</button>


### PR DESCRIPTION
Implementação do aceite da politica de privacidade na redefinição de senha exibida apenas no primeiro login.
Adicionado campo termo_aceito no banco e validação no front-end para exigir o aceite antes de prosseguir.
Redefinições manuais não exibem o checkbox.